### PR TITLE
Fix app.js static file path for serving CSS and assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,12 +3,11 @@ const path = require('path');
 
 const app = express();
 
-// Set EJS as the template engine
 app.set('view engine', 'ejs');
-app.set('views', path.join(__dirname, 'views'));
 
-// Serve static assets from /public
-app.use(express.static(path.join(__dirname, 'public')));
+app.set('views', path.join(__dirname, 'frontend', 'views'));
+
+app.use(express.static(path.join(__dirname, 'frontend', 'public')));
 
 // Routes for EJS templates
 app.get('/', (req, res) => res.render('index'));


### PR DESCRIPTION
Fix static file path for serving CSS and assets in App.js file 
- Updated the static file path to correctly serve assets from the 'frontend/public' directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated directories for views and static assets in the application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->